### PR TITLE
Bump version of the LTS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: haskell/actions/setup@v2
         with:
-          ghc-version: '8.8.4'
+          ghc-version: '9.4.5'
           enable-stack: true
           stack-version: 'latest'
       - name: install deps
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: haskell/actions/setup@v2
         with:
-          ghc-version: '8.8.4'
+          ghc-version: '9.4.5'
           enable-stack: true
           stack-version: 'latest'
       - name: install deps

--- a/lambdananas.cabal
+++ b/lambdananas.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -51,9 +51,9 @@ library
     , filepath >=1.4
     , haskell-src-exts >=1.23
     , mtl >=2.2
-    , optparse-applicative >=0.15 && <0.17
+    , optparse-applicative >=0.15 && <=0.18.1.0
     , regex-tdfa >=1.3 && <2
-    , text >=1.2 && <2
+    , text >=1.2 && <2.1
   default-language: Haskell2010
 
 executable lambdananas-exe
@@ -70,9 +70,9 @@ executable lambdananas-exe
     , haskell-src-exts >=1.23
     , lambdananas
     , mtl >=2.2
-    , optparse-applicative >=0.15 && <0.17
+    , optparse-applicative >=0.15 && <=0.18.1.0
     , regex-tdfa >=1.3 && <2
-    , text >=1.2 && <2
+    , text >=1.2 && <2.1
   default-language: Haskell2010
 
 test-suite integration-tests
@@ -91,7 +91,7 @@ test-suite integration-tests
     , hspec >=2.7
     , lambdananas
     , mtl >=2.2
-    , optparse-applicative >=0.15 && <0.17
+    , optparse-applicative >=0.15 && <=0.18.1.0
     , regex-tdfa >=1.3 && <2
-    , text >=1.2 && <2
+    , text >=1.2 && <2.1
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -11,12 +11,12 @@ extra-source-files:
 
 dependencies:
 - base >= 4.7 && < 5
-- optparse-applicative >= 0.15 && < 0.17
+- optparse-applicative >= 0.15 && <= 0.18.1.0
 - mtl >= 2.2
 - directory >= 1.3
 - filepath >= 1.4
 - haskell-src-exts >= 1.23
-- text >= 1.2 && < 2
+- text >= 1.2 && < 2.1
 - regex-tdfa >= 1.3 && < 2
 
 library:

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,6 +4,6 @@
 # For advanced use and comprehensive documentation of the format, please see:
 # https://docs.haskellstack.org/en/stable/yaml_configuration/
 
-resolver: lts-16.27
+resolver: lts-21.7
 packages:
 - .

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 533252
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/27.yaml
-    sha256: c2aaae52beeacf6a5727c1010f50e89d03869abfab6d2c2658ade9da8ed50c73
-  original: lts-16.27
+    sha256: 23bb9bb355bfdb1635252e120a29b712f0d5e8a6c6a65c5ab5bd6692f46c438e
+    size: 640457
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/7.yaml
+  original: lts-21.7


### PR DESCRIPTION
 The previous version of the LTS (16.27) used GHC 8.8.4 which is not available for the arm64 architecture (e.g. Mac with M1 Chip).

This commit/PR bumps the LTS to a newer version (21.7, released in August 2023) along with the compiler (9.4.5). Additionally, the GitHub Action workflows have been updated so that they use the correct version of GHC).