### PR TITLE
chore: update resolver to 22.13

### DIFF
--- a/lambdananas.cabal
+++ b/lambdananas.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -51,9 +51,9 @@ library
     , filepath >=1.4
     , haskell-src-exts >=1.23
     , mtl >=2.2
-    , optparse-applicative >=0.15 && <0.17
+    , optparse-applicative >=0.18
     , regex-tdfa >=1.3 && <2
-    , text >=1.2 && <2
+    , text >=2.0
   default-language: Haskell2010
 
 executable lambdananas-exe
@@ -70,9 +70,9 @@ executable lambdananas-exe
     , haskell-src-exts >=1.23
     , lambdananas
     , mtl >=2.2
-    , optparse-applicative >=0.15 && <0.17
+    , optparse-applicative >=0.18
     , regex-tdfa >=1.3 && <2
-    , text >=1.2 && <2
+    , text >=2.0
   default-language: Haskell2010
 
 test-suite integration-tests
@@ -91,7 +91,7 @@ test-suite integration-tests
     , hspec >=2.7
     , lambdananas
     , mtl >=2.2
-    , optparse-applicative >=0.15 && <0.17
+    , optparse-applicative >=0.18
     , regex-tdfa >=1.3 && <2
-    , text >=1.2 && <2
+    , text >=2.0
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -11,12 +11,12 @@ extra-source-files:
 
 dependencies:
 - base >= 4.7 && < 5
-- optparse-applicative >= 0.15 && < 0.17
+- optparse-applicative >= 0.18
 - mtl >= 2.2
 - directory >= 1.3
 - filepath >= 1.4
 - haskell-src-exts >= 1.23
-- text >= 1.2 && < 2
+- text >= 2.0
 - regex-tdfa >= 1.3 && < 2
 
 library:

--- a/src/rules/BadDo.hs
+++ b/src/rules/BadDo.hs
@@ -10,6 +10,8 @@ module BadDo (
 ) where
 
 import Common
+import Data.Monoid (Sum(..))
+import Control.Monad (join)
 
 check :: Check
 check presult = (join . explore checkDo) (decls presult)

--- a/src/rules/BadDoReturn.hs
+++ b/src/rules/BadDoReturn.hs
@@ -14,6 +14,7 @@ module BadDoReturn (
 ) where
 
 import Common
+import Control.Monad (join)
 
 check :: Check
 check presult = (join . explore checkReturn) (decls presult)

--- a/src/rules/BadGuard.hs
+++ b/src/rules/BadGuard.hs
@@ -11,6 +11,7 @@ module BadGuard (
 
 import Common
 import Data.Foldable
+import Control.Monad (join)
 
 check :: Check
 check presult = join $ explore checkGuard (decls presult)

--- a/src/rules/BadIf.hs
+++ b/src/rules/BadIf.hs
@@ -10,6 +10,8 @@ module BadIf (
 ) where
 
 import Common
+import Data.Monoid (Sum(..))
+import Control.Monad (join)
 
 check :: Check
 check presult = (join . explore checkIf) (decls presult)

--- a/src/rules/FunctionTooWideOrLarge.hs
+++ b/src/rules/FunctionTooWideOrLarge.hs
@@ -10,6 +10,7 @@ module FunctionTooWideOrLarge (
 ) where
 
 import Common
+import Control.Monad (join)
 
 check :: Check
 check presult = uniqWarn $ join $ explore checkLine (decls presult)

--- a/src/rules/NoSig.hs
+++ b/src/rules/NoSig.hs
@@ -10,6 +10,7 @@ module NoSig (
 ) where
 
 import Common
+import Control.Monad (join)
 
 check :: Check
 check presult = join $ map genWarn binds

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,6 +4,6 @@
 # For advanced use and comprehensive documentation of the format, please see:
 # https://docs.haskellstack.org/en/stable/yaml_configuration/
 
-resolver: lts-16.27
+resolver: lts-22.13
 packages:
 - .

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 533252
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/27.yaml
-    sha256: c2aaae52beeacf6a5727c1010f50e89d03869abfab6d2c2658ade9da8ed50c73
-  original: lts-16.27
+    sha256: 6f0bea3ba5b07360f25bc886e8cff8d847767557a492a6f7f6dcb06e3cc79ee9
+    size: 712905
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/13.yaml
+  original: lts-22.13


### PR DESCRIPTION
In order for Lambdananas to work with Mac silicon, we needed to update the GHC version.

This is being done here, along with a couple fixes coming from breaking changes in GHC